### PR TITLE
fix: Bump Collector and Mutator version to use Update values.yaml

### DIFF
--- a/slimstack/values.yaml
+++ b/slimstack/values.yaml
@@ -169,7 +169,7 @@ mutator:
   replicas: 2
   image:
     repository: public.ecr.aws/slimstack/mutator
-    tag: 0.4.31
+    tag: 0.4.32
     pullPolicy: Always
   wandControl: false
   debugLog: false
@@ -192,7 +192,7 @@ collector:
   replicas: 1
   image:
     repository: public.ecr.aws/slimstack/collector
-    tag: 0.2.51
+    tag: 0.2.52
     pullPolicy: Always
   wandControl: false
   debugLog: false


### PR DESCRIPTION
bump collector and mutator to use new version of wand-go-libs v0.3.3 